### PR TITLE
fix: increase cluster test timeouts to prevent flaky CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }}, Go ${{ matrix.go-version }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: read
     strategy:
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run tests (full, with integration)
         if: matrix.os == 'ubuntu-latest' && matrix.go-version == 'stable'
-        run: go test -v -race -count=1 -timeout 14m -coverprofile=coverage.out ./...
+        run: go test -v -race -count=1 -timeout 20m -coverprofile=coverage.out ./...
 
       - name: Upload Coverage
         if: matrix.os == 'ubuntu-latest' && matrix.go-version == 'stable'

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test:
 
 .PHONY: test-integration
 test-integration:
-	go test -v -race -count=1 ./...
+	go test -v -race -count=1 -timeout 20m ./...
 
 .PHONY: clean
 clean:

--- a/cluster.go
+++ b/cluster.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultClusterStartTimeout = 120 * time.Second
+	defaultClusterStartTimeout = 180 * time.Second
 	keeperQuorumPollInterval   = 500 * time.Millisecond
 	minReplicas                = 2
 )


### PR DESCRIPTION
## Summary
- Bump `defaultClusterStartTimeout` from 120s to 180s (60s per node in a 3-node cluster)
- Increase CI Go test timeout from 14m to 20m
- Increase CI job-level timeout from 15min to 25min
- Add `-timeout 20m` to Makefile `test-integration` target for consistency

## Context
Cluster integration tests (`TestIntegration_ClusterKeeperMetadata`, `TestIntegration_ClusterDistributedQuery`) fail with timeout at exactly 120s on resource-constrained CI runners. The timeout is only a ceiling — tests return immediately when nodes are healthy.

## Test plan
- [x] `go test -short -race -count=1 ./...` — unit tests pass
- [x] `golangci-lint run ./...` — zero issues
- [ ] CI integration tests pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased timeout thresholds across test execution and cluster initialization to improve reliability during extended test scenarios and reduce timeout-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->