### PR TITLE
feat: add ClickHouse v26.3 LTS support and set as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ func TestQuery(t *testing.T) {
 
 | Configuration      | Default                                              |
 |--------------------|------------------------------------------------------|
-| Version            | `V25_8` (25.8.16.34-lts)                            |
+| Version            | `V26_3` (26.3.2.3-lts)                              |
 | TCP Port           | Auto-allocated                                       |
 | HTTP Port          | Auto-allocated                                       |
 | Cache Path         | `$XDG_CACHE_HOME/embedded-clickhouse/` or `~/.cache/embedded-clickhouse/` |
@@ -250,8 +250,9 @@ custom := base.Version(embeddedclickhouse.V25_3) // base is unchanged
 
 | Constant | Version               | Channel |
 |----------|-----------------------|---------|
+| `V26_3`  | 26.3.2.3-lts          | LTS (default) |
 | `V26_1`  | 26.1.3.52-stable      | Stable  |
-| `V25_8`  | 25.8.16.34-lts        | LTS (default) |
+| `V25_8`  | 25.8.16.34-lts        | LTS     |
 | `V25_3`  | 25.3.14.14-lts        | LTS     |
 
 Any version string can be used — these constants are provided for convenience. Pass the full version from a [ClickHouse release tag](https://github.com/ClickHouse/ClickHouse/releases), e.g. `embeddedclickhouse.ClickHouseVersion("24.8.6.70-lts")`.

--- a/config.go
+++ b/config.go
@@ -10,6 +10,9 @@ import (
 // ClickHouseVersion represents a ClickHouse server version string.
 type ClickHouseVersion string
 
+// V26_3 is ClickHouse 26.3 (LTS channel).
+const V26_3 ClickHouseVersion = "26.3.2.3-lts"
+
 // V26_1 is ClickHouse 26.1 (stable channel).
 const V26_1 ClickHouseVersion = "26.1.3.52-stable"
 
@@ -20,7 +23,7 @@ const V25_8 ClickHouseVersion = "25.8.16.34-lts"
 const V25_3 ClickHouseVersion = "25.3.14.14-lts"
 
 // DefaultVersion is the default ClickHouse version used when none is specified.
-const DefaultVersion = V25_8
+const DefaultVersion = V26_3
 
 // Config holds configuration for an embedded ClickHouse server.
 type Config struct {

--- a/platform_test.go
+++ b/platform_test.go
@@ -97,6 +97,7 @@ func TestNumericVersion(t *testing.T) {
 		in   ClickHouseVersion
 		want string
 	}{
+		{V26_3, "26.3.2.3"},
 		{V25_8, "25.8.16.34"},
 		{V25_3, "25.3.14.14"},
 		{V26_1, "26.1.3.52"},


### PR DESCRIPTION
Add V26_3 constant for the latest LTS release (26.3.2.3-lts) and update DefaultVersion to use it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default ClickHouse version to 26.3.2.3-lts
  * Added support for ClickHouse version 26.3

* **Documentation**
  * Updated version availability and defaults table in documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->