### PR TITLE
fix: cross-process cache integrity (flock + atomic temp files)

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -1,7 +1,7 @@
 tools:
   - name: golangci-lint
     version:
-      want: v2.10.1
+      want: v2.12.2
     method: github-release
     with:
       repo: golangci/golangci-lint

--- a/cache.go
+++ b/cache.go
@@ -46,3 +46,9 @@ func customCachedBinaryPath(cacheDir, hashInput string) string {
 
 	return filepath.Join(cacheDir, "custom-"+key)
 }
+
+// lockPathFor returns the sidecar advisory-lock file path for a cached binary path.
+// The lock file lives next to the binary so it shares the same (already created) directory.
+func lockPathFor(binPath string) string {
+	return binPath + ".lock"
+}

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -56,6 +56,9 @@ var ErrInvalidSettingKey = errors.New("embedded-clickhouse: invalid setting key"
 // ErrClusterManaged is returned when Start or Stop is called on a node owned by a Cluster.
 var ErrClusterManaged = errors.New("embedded-clickhouse: node is managed by a cluster; use Cluster.Start/Stop")
 
+// ErrLockingUnsupported is returned when cross-process file locking is not supported on the current platform.
+var ErrLockingUnsupported = errors.New("embedded-clickhouse: file locking not supported on this platform")
+
 // EmbeddedClickHouse manages a ClickHouse server process for testing.
 type EmbeddedClickHouse struct {
 	config Config

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"sync"
 	"testing"
 )
@@ -120,8 +121,8 @@ func (e *EmbeddedClickHouse) Start() error { //nolint:cyclop // cluster guard ad
 
 	cleanups := make([]func(), 0)
 	cleanup := func() {
-		for i := len(cleanups) - 1; i >= 0; i-- {
-			cleanups[i]()
+		for _, cleanup := range slices.Backward(cleanups) {
+			cleanup()
 		}
 	}
 

--- a/cluster.go
+++ b/cluster.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -101,8 +102,8 @@ func (c *Cluster) Start() error { //nolint:funlen // multi-phase orchestrator
 
 	cleanups := make([]func(), 0)
 	cleanup := func() {
-		for i := len(cleanups) - 1; i >= 0; i-- {
-			cleanups[i]()
+		for _, cleanup := range slices.Backward(cleanups) {
+			cleanup()
 		}
 	}
 
@@ -211,9 +212,7 @@ func (c *Cluster) Stop() error {
 	var errs []error
 
 	// Stop in reverse order.
-	for i := len(c.nodes) - 1; i >= 0; i-- {
-		node := c.nodes[i]
-
+	for i, node := range slices.Backward(c.nodes) {
 		node.mu.Lock()
 
 		if err := stopProcess(node.cmd, c.config.stopTimeout); err != nil {

--- a/cluster_config_test.go
+++ b/cluster_config_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 )
 
+const testKeyMaxServerMemoryUsage = "max_server_memory_usage"
+
 func threeNodeTopology() clusterTopology {
 	ports := []clusterNodePorts{
 		{TCP: 19000, HTTP: 18123, Interserver: 19009, Keeper: 19181, KeeperRaft: 19234},
@@ -151,11 +153,11 @@ func TestBuildClusterTopology_UserSettings(t *testing.T) {
 	topo := buildClusterTopology([]clusterNodePorts{
 		{TCP: 1, HTTP: 2, Interserver: 3, Keeper: 4, KeeperRaft: 5},
 	}, map[string]string{
-		"max_server_memory_usage": "2147483648",
+		testKeyMaxServerMemoryUsage: "2147483648",
 	})
 
-	if topo.Settings["max_server_memory_usage"] != "2147483648" {
-		t.Errorf("expected user setting, got %s", topo.Settings["max_server_memory_usage"])
+	if topo.Settings[testKeyMaxServerMemoryUsage] != "2147483648" {
+		t.Errorf("expected user setting, got %s", topo.Settings[testKeyMaxServerMemoryUsage])
 	}
 }
 
@@ -165,9 +167,9 @@ func TestWriteClusterNodeConfig_SettingsSortedDeterministically(t *testing.T) {
 	topo := buildClusterTopology(
 		[]clusterNodePorts{{TCP: 1, HTTP: 2, Interserver: 3, Keeper: 4, KeeperRaft: 5}},
 		map[string]string{
-			"max_memory_usage":        "1000000000",
-			"allow_introspection":     "1",
-			"max_server_memory_usage": "2147483648",
+			"max_memory_usage":          "1000000000",
+			"allow_introspection":       "1",
+			testKeyMaxServerMemoryUsage: "2147483648",
 		},
 	)
 	dir := t.TempDir()

--- a/download.go
+++ b/download.go
@@ -10,11 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 )
-
-var downloadMu sync.Mutex //nolint:gochecknoglobals // serializes concurrent binary downloads
 
 // httpClient is a shared HTTP client with a timeout to prevent indefinite hangs on slow CDNs.
 var httpClient = &http.Client{Timeout: 10 * time.Minute} //nolint:gochecknoglobals
@@ -64,6 +61,23 @@ func ensureCustomArchiveFromPath(cfg Config) (string, error) {
 
 	binPath := customCachedBinaryPath(dir, contentHash)
 
+	// Lock-free fast path.
+	if _, err := os.Stat(binPath); err == nil {
+		return binPath, nil
+	}
+
+	// The lock file lives in dir, so the directory must exist before locking.
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("embedded-clickhouse: create cache dir: %w", err)
+	}
+
+	lock, err := acquireLock(lockPathFor(binPath))
+	if err != nil {
+		return "", err
+	}
+	defer lock.release() //nolint:errcheck
+
+	// Re-stat under the lock: another process/goroutine may have extracted it.
 	if _, err := os.Stat(binPath); err == nil {
 		return binPath, nil
 	}
@@ -90,25 +104,37 @@ func ensureCustomArchiveFromURL(cfg Config) (string, error) {
 	cacheInput := cfg.customArchiveURL + "\x00" + strings.ToLower(cfg.sha256) + "\x00" + strings.ToLower(cfg.sha512hash)
 	binPath := customCachedBinaryPath(dir, cacheInput)
 
+	// Lock-free fast path.
 	if _, err := os.Stat(binPath); err == nil {
 		return binPath, nil
 	}
 
-	downloadMu.Lock()
-	defer downloadMu.Unlock()
+	// The lock file lives in dir, so the directory must exist before locking.
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("embedded-clickhouse: create cache dir: %w", err)
+	}
 
-	// Double-check after acquiring lock.
+	lock, err := acquireLock(lockPathFor(binPath))
+	if err != nil {
+		return "", err
+	}
+	defer lock.release() //nolint:errcheck
+
+	// Re-stat under the lock: another process/goroutine may have downloaded it.
 	if _, err := os.Stat(binPath); err == nil {
 		return binPath, nil
 	}
 
 	logf(cfg.logger, "Downloading ClickHouse from %s...\n", cfg.customArchiveURL)
 
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", fmt.Errorf("embedded-clickhouse: create cache dir: %w", err)
+	archiveFile, err := os.CreateTemp(dir, filepath.Base(binPath)+".tar.gz.*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("embedded-clickhouse: create temp file: %w", err)
 	}
 
-	archivePath := binPath + ".tar.gz.tmp"
+	archivePath := archiveFile.Name()
+	archiveFile.Close()
+
 	defer os.Remove(archivePath)
 
 	if err := downloadFile(cfg.customArchiveURL, archivePath); err != nil {
@@ -137,14 +163,23 @@ func ensureStandardBinary(cfg Config) (string, error) {
 
 	binPath := cachedBinaryPath(dir, cfg.version)
 
+	// Lock-free fast path.
 	if _, err := os.Stat(binPath); err == nil {
 		return binPath, nil
 	}
 
-	downloadMu.Lock()
-	defer downloadMu.Unlock()
+	// The lock file lives in dir, so the directory must exist before locking.
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("embedded-clickhouse: create cache dir: %w", err)
+	}
 
-	// Double-check after acquiring lock.
+	lock, err := acquireLock(lockPathFor(binPath))
+	if err != nil {
+		return "", err
+	}
+	defer lock.release() //nolint:errcheck
+
+	// Re-stat under the lock: another process/goroutine may have downloaded it.
 	if _, err := os.Stat(binPath); err == nil {
 		return binPath, nil
 	}
@@ -186,7 +221,14 @@ func downloadAndExtract(cfg Config, url string, asset platformAsset, binPath str
 		return fmt.Errorf("embedded-clickhouse: create cache dir: %w", err)
 	}
 
-	archivePath := filepath.Join(dir, asset.filename+".tmp")
+	archiveFile, err := os.CreateTemp(dir, asset.filename+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("embedded-clickhouse: create temp file: %w", err)
+	}
+
+	archivePath := archiveFile.Name()
+	archiveFile.Close()
+
 	defer os.Remove(archivePath)
 
 	if err := downloadFile(url, archivePath); err != nil {
@@ -208,7 +250,15 @@ func downloadRawBinary(cfg Config, asset platformAsset, url, binPath string) err
 		return fmt.Errorf("embedded-clickhouse: create cache dir: %w", err)
 	}
 
-	tmp := binPath + ".tmp"
+	tmpFile, err := os.CreateTemp(filepath.Dir(binPath), filepath.Base(binPath)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("embedded-clickhouse: create temp file: %w", err)
+	}
+
+	tmp := tmpFile.Name()
+	tmpFile.Close()
+
+	defer os.Remove(tmp)
 
 	if err := downloadFile(url, tmp); err != nil {
 		return err
@@ -217,17 +267,14 @@ func downloadRawBinary(cfg Config, asset platformAsset, url, binPath string) err
 	sha512url := sha512URL(cfg.binaryRepositoryURL, cfg.version, asset)
 
 	if err := verifySHA512(tmp, sha512url, asset.filename, cfg.logger); err != nil {
-		os.Remove(tmp)
 		return err
 	}
 
 	if err := os.Chmod(tmp, 0o755); err != nil {
-		os.Remove(tmp)
 		return fmt.Errorf("embedded-clickhouse: chmod binary: %w", err)
 	}
 
 	if err := os.Rename(tmp, binPath); err != nil {
-		os.Remove(tmp)
 		return fmt.Errorf("embedded-clickhouse: rename binary: %w", err)
 	}
 

--- a/download_test.go
+++ b/download_test.go
@@ -247,7 +247,7 @@ func TestDownloadRawBinary_WithVerification(t *testing.T) {
 	binaryContent := []byte("fake clickhouse binary")
 	h := sha512.Sum512(binaryContent)
 	expectedHash := hex.EncodeToString(h[:])
-	filename := "clickhouse-macos"
+	filename := assetMacOS
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, ".sha512") {
@@ -281,7 +281,7 @@ func TestDownloadRawBinary_SHA512Unavailable(t *testing.T) {
 	t.Parallel()
 
 	binaryContent := []byte("fake binary no sha512")
-	filename := "clickhouse-macos"
+	filename := assetMacOS
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, ".sha512") {

--- a/download_test.go
+++ b/download_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -299,6 +300,108 @@ func TestDownloadRawBinary_SHA512Unavailable(t *testing.T) {
 
 	if err := downloadRawBinary(cfg, asset, ts.URL+"/"+filename, binPath); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestEnsureStandardBinary_ConcurrentSameProcess verifies that many goroutines sharing
+// one cache directory converge on the same binary without corrupting it. The advisory
+// file lock serializes the download/extract; the fast-path stat hits for the rest.
+func TestEnsureStandardBinary_ConcurrentSameProcess(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+
+	cfg := DefaultConfig().CachePath(cacheDir).Logger(io.Discard)
+
+	asset, err := resolveCurrentPlatformAsset(cfg.version)
+	if err != nil {
+		t.Skipf("platform has no standard asset: %v", err)
+	}
+
+	if asset.assetType != assetArchive {
+		t.Skipf("standard asset for this platform is not an archive (type %d); concurrent archive path not exercised", asset.assetType)
+	}
+
+	// Build an archive whose contents match what the server will serve, and compute
+	// its SHA512 so the .sha512 endpoint validates.
+	archivePath := createTestArchive(t, t.TempDir())
+
+	archiveContent, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := sha512.Sum512(archiveContent)
+	expectedHash := hex.EncodeToString(h[:])
+
+	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ".sha512") {
+			fmt.Fprintf(rw, "%s  %s\n", expectedHash, asset.filename)
+			return
+		}
+
+		rw.Write(archiveContent)
+	}))
+	defer ts.Close()
+
+	cfg = cfg.BinaryRepositoryURL(ts.URL)
+
+	const goroutines = 8
+
+	var wg sync.WaitGroup
+
+	start := make(chan struct{})
+
+	paths := make([]string, goroutines)
+	errs := make([]error, goroutines)
+
+	for i := range goroutines {
+		wg.Add(1)
+
+		go func(idx int) {
+			defer wg.Done()
+
+			<-start
+
+			paths[idx], errs[idx] = ensureBinary(cfg)
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	want := cachedBinaryPath(cacheDir, cfg.version)
+
+	for i := range goroutines {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d: ensureBinary failed: %v", i, errs[i])
+		}
+
+		if paths[i] != want {
+			t.Errorf("goroutine %d: binPath = %q, want %q", i, paths[i], want)
+		}
+	}
+
+	// Final binary exists and is executable.
+	info, err := os.Stat(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode()&0o111 == 0 {
+		t.Error("cached binary is not executable")
+	}
+
+	// No stray "*.tmp" orphans should remain (the ".lock" sidecar is expected).
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("stray temp file remained: %s", e.Name())
+		}
 	}
 }
 

--- a/extract.go
+++ b/extract.go
@@ -76,12 +76,13 @@ func writeExecutable(r io.Reader, destPath string) error {
 		return fmt.Errorf("embedded-clickhouse: create directory: %w", err)
 	}
 
-	tmp := destPath + ".tmp"
-
-	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	// Unique temp name so concurrent writers never truncate each other's in-flight file.
+	out, err := os.CreateTemp(filepath.Dir(destPath), filepath.Base(destPath)+".*.tmp")
 	if err != nil {
 		return fmt.Errorf("embedded-clickhouse: create temp file: %w", err)
 	}
+
+	tmp := out.Name()
 
 	if _, err := io.Copy(out, r); err != nil {
 		out.Close()
@@ -93,6 +94,13 @@ func writeExecutable(r io.Reader, destPath string) error {
 	if err := out.Close(); err != nil {
 		os.Remove(tmp)
 		return fmt.Errorf("embedded-clickhouse: close temp file: %w", err)
+	}
+
+	// os.CreateTemp creates the file with 0600; restore the executable bit before the
+	// atomic rename so the cached binary is runnable (load-bearing: tests assert this).
+	if err := os.Chmod(tmp, 0o755); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("embedded-clickhouse: chmod temp file: %w", err)
 	}
 
 	if err := os.Rename(tmp, destPath); err != nil {

--- a/extract_test.go
+++ b/extract_test.go
@@ -1,8 +1,11 @@
 package embeddedclickhouse
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -62,5 +65,94 @@ func TestExtractClickHouseBinary_NotATgz(t *testing.T) {
 	err := extractClickHouseBinary(tmpFile, filepath.Join(t.TempDir(), "clickhouse"))
 	if err == nil {
 		t.Fatal("expected error for non-gzip file")
+	}
+}
+
+// TestWriteExecutable_ConcurrentNoTruncate runs N writeExecutable calls against the
+// SAME destination with distinct-length payloads. Because each writer uses a unique
+// temp file and an atomic rename, the final file must equal exactly ONE input length
+// (a winner), never a truncated or interleaved mix.
+func TestWriteExecutable_ConcurrentNoTruncate(t *testing.T) {
+	t.Parallel()
+
+	destPath := filepath.Join(t.TempDir(), "clickhouse")
+
+	const writers = 8
+
+	// Build a payload per writer, each with a unique byte and a unique length.
+	payloads := make([][]byte, writers)
+	lengths := make(map[int]bool, writers)
+
+	for i := range writers {
+		length := 100 + i*37
+		payloads[i] = bytes.Repeat([]byte{byte('A' + i)}, length)
+		lengths[length] = true
+	}
+
+	var wg sync.WaitGroup
+
+	start := make(chan struct{})
+
+	errs := make([]error, writers)
+
+	for i := range writers {
+		wg.Add(1)
+
+		go func(idx int) {
+			defer wg.Done()
+
+			<-start
+
+			errs[idx] = writeExecutable(bytes.NewReader(payloads[idx]), destPath)
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("writer %d failed: %v", i, err)
+		}
+	}
+
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The final file must be exactly one of the inputs: a single repeated byte of a
+	// known length (never a truncated/interleaved mix).
+	if !lengths[len(got)] {
+		t.Fatalf("final file length %d is not one of the input lengths %v", len(got), lengths)
+	}
+
+	if len(got) > 0 {
+		want := strings.Repeat(string(got[0:1]), len(got))
+		if string(got) != want {
+			t.Fatalf("final file is not a single uninterleaved payload (first byte %q)", got[0])
+		}
+	}
+
+	// Final file must be executable after the chmod.
+	info, err := os.Stat(destPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode()&0o111 == 0 {
+		t.Error("final file is not executable")
+	}
+
+	// No stray temp files should remain in the directory.
+	entries, err := os.ReadDir(filepath.Dir(destPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("stray temp file remained: %s", e.Name())
+		}
 	}
 }

--- a/filelock_other.go
+++ b/filelock_other.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package embeddedclickhouse
+
+// fileLock is a stub on platforms without flock(2) support. The package builds, but
+// acquireLock always fails with ErrLockingUnsupported.
+type fileLock struct{}
+
+// acquireLock is unsupported on this platform and always returns ErrLockingUnsupported.
+func acquireLock(_ string) (*fileLock, error) {
+	return nil, ErrLockingUnsupported
+}
+
+// release is a no-op on this platform.
+func (l *fileLock) release() error {
+	return nil
+}

--- a/filelock_test.go
+++ b/filelock_test.go
@@ -1,0 +1,71 @@
+//go:build !windows
+
+package embeddedclickhouse
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAcquireLock_Mutex verifies that a second acquire on the same lock path blocks
+// until the first holder releases. Uses channels (not sleeps) for the positive proof.
+func TestAcquireLock_Mutex(t *testing.T) {
+	t.Parallel()
+
+	lockPath := filepath.Join(t.TempDir(), "cache.lock")
+
+	l1, err := acquireLock(lockPath)
+	require.NoError(t, err)
+
+	acquired := make(chan *fileLock, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		l2, err := acquireLock(lockPath)
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		acquired <- l2
+	}()
+
+	// While l1 is held, the second acquire must not succeed.
+	select {
+	case <-acquired:
+		t.Fatal("second acquire succeeded while first lock was held")
+	case err := <-errCh:
+		t.Fatalf("second acquire errored: %v", err)
+	case <-time.After(100 * time.Millisecond):
+		// Expected: still blocked.
+	}
+
+	// Release l1; the blocked goroutine must now acquire the lock.
+	require.NoError(t, l1.release())
+
+	select {
+	case l2 := <-acquired:
+		require.NoError(t, l2.release())
+	case err := <-errCh:
+		t.Fatalf("second acquire errored after release: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("second acquire did not proceed after first lock was released")
+	}
+}
+
+// TestAcquireLock_Sequential verifies that the lock can be acquired and released
+// repeatedly in sequence without blocking.
+func TestAcquireLock_Sequential(t *testing.T) {
+	t.Parallel()
+
+	lockPath := filepath.Join(t.TempDir(), "cache.lock")
+
+	for range 5 {
+		l, err := acquireLock(lockPath)
+		require.NoError(t, err)
+		require.NoError(t, l.release())
+	}
+}

--- a/filelock_unix.go
+++ b/filelock_unix.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package embeddedclickhouse
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// fileLock is a cross-process advisory lock backed by flock(2).
+type fileLock struct {
+	f *os.File
+}
+
+// acquireLock opens (creating if needed) the lock file at lockPath and takes an
+// exclusive advisory lock via flock(2). flock locks are associated with the open
+// file description, so each acquireLock call (which performs its own open) serializes
+// both across processes AND across goroutines within a single process. It blocks until
+// the lock is available.
+func acquireLock(lockPath string) (*fileLock, error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644) //nolint:mnd // standard lock-file perms
+	if err != nil {
+		return nil, fmt.Errorf("embedded-clickhouse: open lock %s: %w", lockPath, err)
+	}
+
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("embedded-clickhouse: acquire lock %s: %w", lockPath, err)
+	}
+
+	return &fileLock{f: f}, nil
+}
+
+// release unlocks and closes the lock file. The lock file itself is never removed,
+// since removing it would defeat the flock-based serialization (another process could
+// create a fresh file and lock that instead while this one is still held).
+func (l *fileLock) release() error {
+	_ = unix.Flock(int(l.f.Fd()), unix.LOCK_UN)
+	return l.f.Close() //nolint:wrapcheck // simple Close error; caller context is clear
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.46.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sys v0.41.0
 )
 
 require (
@@ -24,6 +25,5 @@ require (
 	go.opentelemetry.io/otel v1.41.0 // indirect
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/sys v0.41.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/platform.go
+++ b/platform.go
@@ -8,6 +8,14 @@ import (
 
 const defaultBaseURL = "https://github.com/ClickHouse/ClickHouse/releases/download"
 
+const (
+	archAMD64 = "amd64"
+	archARM64 = "arm64"
+
+	assetMacOS        = "clickhouse-macos"
+	assetMacOSAARCH64 = "clickhouse-macos-aarch64"
+)
+
 type assetType int
 
 const (
@@ -65,10 +73,10 @@ func resolveAsset(version ClickHouseVersion, goos, goarch string) (platformAsset
 
 func linuxArch(goarch string) (string, error) {
 	switch goarch {
-	case "amd64":
-		return "amd64", nil
-	case "arm64":
-		return "arm64", nil
+	case archAMD64:
+		return archAMD64, nil
+	case archARM64:
+		return archARM64, nil
 	default:
 		return "", fmt.Errorf("%w: linux/%s", ErrUnsupportedPlatform, goarch)
 	}
@@ -76,10 +84,10 @@ func linuxArch(goarch string) (string, error) {
 
 func darwinAssetName(goarch string) (string, error) {
 	switch goarch {
-	case "amd64":
-		return "clickhouse-macos", nil
-	case "arm64":
-		return "clickhouse-macos-aarch64", nil
+	case archAMD64:
+		return assetMacOS, nil
+	case archARM64:
+		return assetMacOSAARCH64, nil
 	default:
 		return "", fmt.Errorf("%w: darwin/%s", ErrUnsupportedPlatform, goarch)
 	}

--- a/platform_test.go
+++ b/platform_test.go
@@ -12,8 +12,8 @@ func TestResolveAsset_Linux(t *testing.T) {
 		arch     string
 		wantFile string
 	}{
-		{"amd64", "clickhouse-common-static-25.8.16.34-amd64.tgz"},
-		{"arm64", "clickhouse-common-static-25.8.16.34-arm64.tgz"},
+		{archAMD64, "clickhouse-common-static-25.8.16.34-amd64.tgz"},
+		{archARM64, "clickhouse-common-static-25.8.16.34-arm64.tgz"},
 	}
 	for _, tt := range tests {
 		t.Run("linux/"+tt.arch, func(t *testing.T) {
@@ -42,8 +42,8 @@ func TestResolveAsset_Darwin(t *testing.T) {
 		arch     string
 		wantFile string
 	}{
-		{"amd64", "clickhouse-macos"},
-		{"arm64", "clickhouse-macos-aarch64"},
+		{archAMD64, assetMacOS},
+		{archARM64, assetMacOSAARCH64},
 	}
 	for _, tt := range tests {
 		t.Run("darwin/"+tt.arch, func(t *testing.T) {
@@ -73,10 +73,10 @@ func TestResolveAsset_Unsupported(t *testing.T) {
 		goos string
 		arch string
 	}{
-		{"windows", "windows", "amd64"},
+		{"windows", "windows", archAMD64},
 		{"linux/386", "linux", "386"},
 		{"darwin/386", "darwin", "386"},
-		{"freebsd", "freebsd", "amd64"},
+		{"freebsd", "freebsd", archAMD64},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -131,7 +131,7 @@ func TestDownloadURL(t *testing.T) {
 func TestDownloadURL_CustomBase(t *testing.T) {
 	t.Parallel()
 
-	asset := platformAsset{filename: "clickhouse-macos-aarch64", assetType: assetRawBinary}
+	asset := platformAsset{filename: assetMacOSAARCH64, assetType: assetRawBinary}
 
 	got := downloadURL("https://mirror.example.com/releases", V25_3, asset)
 
@@ -157,7 +157,7 @@ func TestSHA512URL(t *testing.T) {
 func TestSHA512URL_Darwin(t *testing.T) {
 	t.Parallel()
 
-	asset := platformAsset{filename: "clickhouse-macos-aarch64", assetType: assetRawBinary}
+	asset := platformAsset{filename: assetMacOSAARCH64, assetType: assetRawBinary}
 
 	got := sha512URL("", V25_8, asset)
 

--- a/server_config_test.go
+++ b/server_config_test.go
@@ -72,7 +72,7 @@ func TestWriteServerConfig_OverrideMaxMemory(t *testing.T) {
 
 	dir := t.TempDir()
 	override := "2147483648" // 2 GiB
-	settings := map[string]string{"max_server_memory_usage": override}
+	settings := map[string]string{testKeyMaxServerMemoryUsage: override}
 
 	configPath, err := writeServerConfig(dir, 19000, 18123, settings)
 	if err != nil {
@@ -111,9 +111,9 @@ func TestMergeSettings(t *testing.T) {
 	t.Run("user values pass through", func(t *testing.T) {
 		t.Parallel()
 
-		got := mergeSettings(map[string]string{"max_server_memory_usage": "999"})
-		if got["max_server_memory_usage"] != "999" {
-			t.Errorf("expected value 999, got %q", got["max_server_memory_usage"])
+		got := mergeSettings(map[string]string{testKeyMaxServerMemoryUsage: "999"})
+		if got[testKeyMaxServerMemoryUsage] != "999" {
+			t.Errorf("expected value 999, got %q", got[testKeyMaxServerMemoryUsage])
 		}
 	})
 


### PR DESCRIPTION
Audit items 2 and 3 (REVIEW.md). The download/extract cache had cross-process and in-process races: `downloadMu` was process-local, temp files used deterministic names opened `O_TRUNC` without `O_EXCL`, and freshness was a stat-only check — so two `go test` processes (or goroutines) sharing a cold cache could truncate/delete each others in-flight files and, where verification was skipped, poison the cache permanently.

## Fix
- Per-cache-entry cross-process advisory lock (`flock` on a `.lock` sidecar, build-tagged `filelock_unix.go`) around download+verify+extract, with a fast-path stat and a re-stat under the lock. This subsumes item 3 (`ensureCustomArchiveFromPath` now locks too); `downloadMu` removed.
- Unique temp names via `os.CreateTemp` + atomic same-dir rename at every site; `extract.go` restores the executable bit (`chmod 0755`) after `CreateTemp`s 0600 before renaming.

## Testing
- New `flock` mutex tests, concurrent same-process download test (no orphan temp), and `writeExecutable` no-truncate test — under `-race`.
- Verified end-to-end via a cold-cache integration download (real extract->chmod->rename; `.lock` sidecar present, binary executable).
- `go test -short -race`, `go vet`, `gofmt`, `golangci-lint` (0 issues) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented cross-process file locking mechanism for safe concurrent binary downloads and extraction operations.
  * Added platform-specific file locking support to ensure optimal compatibility across different operating systems.

* **Improvements**
  * Optimized temporary file management with unique naming to prevent conflicts during concurrent operations.
  * Enhanced atomic file operations for improved binary caching reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->