### PR TITLE
fix: reject unsupported single-node options in cluster mode

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -35,6 +35,12 @@ var ErrKeeperNotReady = errors.New("embedded-clickhouse: keeper quorum not ready
 // ErrNodeOutOfRange is returned when Node() is called with an index outside [0, replicas).
 var ErrNodeOutOfRange = errors.New("embedded-clickhouse: node index out of range")
 
+// ErrClusterUnsupportedOption is returned by Cluster.Start when the config sets a data
+// path or explicit port; in cluster mode these are auto-managed and cannot be honored.
+var ErrClusterUnsupportedOption = errors.New(
+	"embedded-clickhouse: ports and data path are auto-managed in cluster mode",
+)
+
 // Cluster manages a multi-replica ClickHouse cluster using embedded Keeper for coordination.
 // All replicas run on localhost with auto-allocated ports. The cluster presents a single
 // shard with N replicas, suitable for testing ReplicatedMergeTree tables with ON CLUSTER queries.
@@ -88,7 +94,7 @@ func NewClusterForTest(tb testing.TB, replicas int, config ...Config) *Cluster {
 }
 
 // Start launches all cluster nodes and waits for Keeper quorum.
-func (c *Cluster) Start() error { //nolint:funlen // multi-phase orchestrator
+func (c *Cluster) Start() error { //nolint:funlen,cyclop // multi-phase orchestrator with config-guard branches
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -98,6 +104,14 @@ func (c *Cluster) Start() error { //nolint:funlen // multi-phase orchestrator
 
 	if c.replicas < minReplicas {
 		return fmt.Errorf("%w: got %d", ErrInvalidReplicaCount, c.replicas)
+	}
+
+	// Cluster mode auto-allocates all ports and uses temp data dirs per node. The
+	// single-node DataPath/TCPPort/HTTPPort options cannot be honored here (a node
+	// needs five ports, and Stop assumes ephemeral temp dirs), so reject them rather
+	// than silently ignore them.
+	if c.config.dataPath != "" || c.config.tcpPort != 0 || c.config.httpPort != 0 {
+		return ErrClusterUnsupportedOption
 	}
 
 	cleanups := make([]func(), 0)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -58,6 +58,28 @@ func TestCluster_InvalidReplicaCount(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidReplicaCount)
 }
 
+func TestCluster_RejectsUnsupportedOptions(t *testing.T) {
+	t.Parallel()
+
+	// Cluster mode auto-manages ports and data dirs; these single-node options must be
+	// rejected before any binary download, so this test stays hermetic. A valid replica
+	// count (3) is used so Start reaches the option-rejection branch.
+	cases := map[string]Config{
+		"DataPath": DefaultConfig().DataPath("/tmp/x"),
+		"TCPPort":  DefaultConfig().TCPPort(19000),
+		"HTTPPort": DefaultConfig().HTTPPort(18123),
+	}
+
+	for name, cfg := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := NewCluster(3, cfg).Start()
+			assert.ErrorIs(t, err, ErrClusterUnsupportedOption)
+		})
+	}
+}
+
 func TestCluster_ClusterName(t *testing.T) {
 	t.Parallel()
 

--- a/config.go
+++ b/config.go
@@ -62,14 +62,16 @@ func (c Config) Version(v ClickHouseVersion) Config {
 }
 
 // TCPPort sets the TCP port for the ClickHouse native protocol.
-// 0 means auto-allocate (default).
+// 0 means auto-allocate (default). Single-node only: Cluster.Start auto-allocates
+// every node's ports and returns ErrClusterUnsupportedOption if this is set.
 func (c Config) TCPPort(port uint32) Config {
 	c.tcpPort = port
 	return c
 }
 
 // HTTPPort sets the HTTP port for the ClickHouse HTTP interface.
-// 0 means auto-allocate (default).
+// 0 means auto-allocate (default). Single-node only: Cluster.Start auto-allocates
+// every node's ports and returns ErrClusterUnsupportedOption if this is set.
 func (c Config) HTTPPort(port uint32) Config {
 	c.httpPort = port
 	return c
@@ -82,6 +84,8 @@ func (c Config) CachePath(path string) Config {
 }
 
 // DataPath sets a persistent data directory that survives Stop.
+// Single-node only: cluster nodes always use per-node temp directories, so
+// Cluster.Start returns ErrClusterUnsupportedOption if this is set.
 func (c Config) DataPath(path string) Config {
 	c.dataPath = path
 	return c


### PR DESCRIPTION
Audit item 6 (REVIEW.md). `Cluster.Start` silently ignored `DataPath`/`TCPPort`/`HTTPPort` (always auto-allocated ports + `os.MkdirTemp`). The "deletes persistent data" sub-claim was unreachable today (a latent footgun), but the silent option-dropping is real.

## Fix
- `Cluster.Start` now rejects a `Config` with `DataPath`, `TCPPort`, or `HTTPPort` set, returning the new `ErrClusterUnsupportedOption`. The guard sits before any network/fs work.
- `config.go` docs clarified that these options are single-node only.

Chose reject-and-validate over honor-the-options: a cluster node needs 5 ports but `Config` exposes 2, and the `Cluster` type commits to auto-allocation — partial honoring would be a worse half-feature (YAGNI).

## Testing
- New hermetic `TestCluster_RejectsUnsupportedOptions` (no binary download).
- `go test -short -race`, `go vet`, `gofmt`, `golangci-lint` (0 issues) all green.

> **Stacked on `fix/p1-process-monitoring`** — review/merge that first; this PRs diff is only the cluster-validation change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster mode now rejects unsupported configuration options (data path and explicit port settings) with a clear error message.

* **Documentation**
  * Updated configuration documentation to clarify auto-allocation behavior and cluster mode constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->