### PR TITLE
fix: fail-closed checksum policy + credential redaction

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -37,6 +37,10 @@ var ErrSHA512Mismatch = errors.New("embedded-clickhouse: SHA512 mismatch")
 // ErrSHA512NotFound is returned when the SHA512 checksum file does not contain a hash for the expected filename.
 var ErrSHA512NotFound = errors.New("embedded-clickhouse: SHA512 hash not found")
 
+// ErrSHA512Unavailable is returned when the SHA512 checksum file cannot be fetched (non-200)
+// and AllowMissingChecksum has not been enabled.
+var ErrSHA512Unavailable = errors.New("embedded-clickhouse: SHA512 checksum unavailable")
+
 // ErrBinaryNotFound is returned when the ClickHouse binary cannot be located inside a downloaded archive.
 var ErrBinaryNotFound = errors.New("embedded-clickhouse: binary not found in archive")
 

--- a/config.go
+++ b/config.go
@@ -27,22 +27,23 @@ const DefaultVersion = V26_3
 
 // Config holds configuration for an embedded ClickHouse server.
 type Config struct {
-	version             ClickHouseVersion
-	tcpPort             uint32
-	httpPort            uint32
-	cachePath           string
-	dataPath            string
-	binaryPath          string
-	binaryRepositoryURL string
-	customArchivePath   string
-	customArchiveURL    string
-	sha256              string
-	sha512hash          string
-	startTimeout        time.Duration
-	startTimeoutSet     bool
-	stopTimeout         time.Duration
-	logger              io.Writer
-	settings            map[string]string
+	version              ClickHouseVersion
+	tcpPort              uint32
+	httpPort             uint32
+	cachePath            string
+	dataPath             string
+	binaryPath           string
+	binaryRepositoryURL  string
+	customArchivePath    string
+	customArchiveURL     string
+	sha256               string
+	sha512hash           string
+	allowMissingChecksum bool
+	startTimeout         time.Duration
+	startTimeoutSet      bool
+	stopTimeout          time.Duration
+	logger               io.Writer
+	settings             map[string]string
 }
 
 // DefaultConfig returns a Config with sensible defaults.
@@ -129,6 +130,18 @@ func (c Config) SHA256(hash string) Config {
 // Only used with CustomArchivePath or CustomArchiveURL.
 func (c Config) SHA512(hash string) Config {
 	c.sha512hash = hash
+	return c
+}
+
+// AllowMissingChecksum controls whether a missing (non-200) SHA512 checksum file is
+// tolerated for archive downloads (the Linux .tgz path). The default (false) is strict:
+// a missing checksum fails the download with ErrSHA512Unavailable. Set to true for an
+// air-gapped or internal mirror that serves archives without a .sha512.
+//
+// This does not affect raw-binary downloads (the macOS path): ClickHouse publishes no
+// checksum for those, so a missing one is always tolerated regardless of this setting.
+func (c Config) AllowMissingChecksum(allow bool) Config {
+	c.allowMissingChecksum = allow
 	return c
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -126,6 +126,25 @@ func TestConfigBuilderChaining_CustomAssets(t *testing.T) {
 	}
 }
 
+func TestConfigAllowMissingChecksum(t *testing.T) {
+	t.Parallel()
+
+	base := DefaultConfig()
+	if base.allowMissingChecksum {
+		t.Error("default allowMissingChecksum should be false (strict)")
+	}
+
+	enabled := base.AllowMissingChecksum(true)
+	if !enabled.allowMissingChecksum {
+		t.Error("AllowMissingChecksum(true) should set the field")
+	}
+
+	// Immutability: the builder must not mutate the receiver.
+	if base.allowMissingChecksum {
+		t.Error("base config was mutated by AllowMissingChecksum")
+	}
+}
+
 func TestConfigBuilderImmutability(t *testing.T) {
 	t.Parallel()
 

--- a/download.go
+++ b/download.go
@@ -4,9 +4,11 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -125,7 +127,7 @@ func ensureCustomArchiveFromURL(cfg Config) (string, error) {
 		return binPath, nil
 	}
 
-	logf(cfg.logger, "Downloading ClickHouse from %s...\n", cfg.customArchiveURL)
+	logf(cfg.logger, "Downloading ClickHouse from %s...\n", redactURL(cfg.customArchiveURL))
 
 	archiveFile, err := os.CreateTemp(dir, filepath.Base(binPath)+".tar.gz.*.tmp")
 	if err != nil {
@@ -238,7 +240,7 @@ func downloadAndExtract(cfg Config, url string, asset platformAsset, binPath str
 	// Verify SHA512 for archives.
 	sha512url := sha512URL(cfg.binaryRepositoryURL, cfg.version, asset)
 
-	if err := verifySHA512(archivePath, sha512url, asset.filename, cfg.logger); err != nil {
+	if err := verifySHA512(archivePath, sha512url, asset.filename, cfg.allowMissingChecksum, cfg.logger); err != nil {
 		return err
 	}
 
@@ -266,7 +268,11 @@ func downloadRawBinary(cfg Config, asset platformAsset, url, binPath string) err
 
 	sha512url := sha512URL(cfg.binaryRepositoryURL, cfg.version, asset)
 
-	if err := verifySHA512(tmp, sha512url, asset.filename, cfg.logger); err != nil {
+	// Raw binaries (macOS) are published without a .sha512 upstream, so a missing
+	// checksum is expected here and must not fail the download — unlike archives,
+	// which always ship one and are verified strictly. A checksum that IS present
+	// is still verified regardless.
+	if err := verifySHA512(tmp, sha512url, asset.filename, true, cfg.logger); err != nil {
 		return err
 	}
 
@@ -284,12 +290,12 @@ func downloadRawBinary(cfg Config, asset platformAsset, url, binPath string) err
 func downloadFile(url, destPath string) error {
 	resp, err := httpClient.Get(url) //nolint:noctx // URL is constructed internally
 	if err != nil {
-		return fmt.Errorf("embedded-clickhouse: download %s: %w", url, err)
+		return fmt.Errorf("embedded-clickhouse: download %s: %w", redactURL(url), redactURLError(err))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("%w: %s: HTTP %d", ErrDownloadFailed, url, resp.StatusCode)
+		return fmt.Errorf("%w: %s: HTTP %d", ErrDownloadFailed, redactURL(url), resp.StatusCode)
 	}
 
 	out, err := os.Create(destPath)
@@ -312,15 +318,20 @@ func downloadFile(url, destPath string) error {
 	return nil
 }
 
-func verifySHA512(filePath, sha512URL, expectedFilename string, logger io.Writer) error {
+func verifySHA512(filePath, sha512URL, expectedFilename string, allowMissing bool, logger io.Writer) error {
 	resp, err := httpClient.Get(sha512URL) //nolint:noctx // URL is constructed internally
 	if err != nil {
-		return fmt.Errorf("embedded-clickhouse: download SHA512: %w", err)
+		return fmt.Errorf("embedded-clickhouse: download SHA512 %s: %w", redactURL(sha512URL), redactURLError(err))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		// SHA512 file not available — skip verification but warn the caller.
+		if !allowMissing {
+			// Fail closed: a missing checksum is a verification failure by default.
+			return fmt.Errorf("%w: %s: HTTP %d", ErrSHA512Unavailable, expectedFilename, resp.StatusCode)
+		}
+
+		// Opt-in fallback: skip verification but warn the caller.
 		logf(logger, "embedded-clickhouse: SHA512 not available for %s (HTTP %d), skipping verification\n",
 			expectedFilename, resp.StatusCode)
 
@@ -351,16 +362,59 @@ func verifySHA512(filePath, sha512URL, expectedFilename string, logger io.Writer
 }
 
 // parseSHA512 parses a sha512sum-format string and returns the hex hash for the given filename.
-// Format: "<hash>  <filename>\n".
+// Format: "<hash>  <filename>\n". It also tolerates two common real-world variants:
+//   - a GNU binary-mode marker ("<hash> *<filename>") and a "./<filename>" prefix on the
+//     filename token, both of which are stripped before comparison;
+//   - a checksum file that contains only a single bare hash (no filename), accepted only
+//     when exactly one hash-looking line is present (ambiguous multi-bare files are rejected).
 func parseSHA512(content, filename string) (string, error) {
+	// A standard sha512sum line is "<hash> <name>" (2 fields); a bare-hash line is 1 field.
+	const hashAndNameFields = 2
+
+	var bareHashes []string
+
 	for line := range strings.SplitSeq(strings.TrimSpace(content), "\n") {
 		parts := strings.Fields(line)
-		if len(parts) >= 2 && parts[1] == filename {
-			return strings.ToLower(parts[0]), nil
+		if len(parts) == 0 {
+			continue
+		}
+
+		// Phase 1: exact filename match (after stripping "*" / "./" markers).
+		if len(parts) >= hashAndNameFields {
+			candidate := strings.TrimPrefix(parts[1], "*")
+			candidate = strings.TrimPrefix(candidate, "./")
+
+			if candidate == filename {
+				return strings.ToLower(parts[0]), nil
+			}
+
+			continue
+		}
+
+		// Collect single-token lines that look like a bare SHA512 hash for phase 2.
+		if isSHA512Hex(parts[0]) {
+			bareHashes = append(bareHashes, strings.ToLower(parts[0]))
 		}
 	}
 
+	// Phase 2: accept a bare hash only when it is unambiguous (exactly one).
+	if len(bareHashes) == 1 {
+		return bareHashes[0], nil
+	}
+
 	return "", fmt.Errorf("%w: %s", ErrSHA512NotFound, filename)
+}
+
+// isSHA512Hex reports whether s is exactly 128 hexadecimal digits (a SHA512 digest).
+func isSHA512Hex(s string) bool {
+	const sha512HexLen = 128
+	if len(s) != sha512HexLen {
+		return false
+	}
+
+	_, err := hex.DecodeString(s)
+
+	return err == nil
 }
 
 func fileSHA512(path string) (string, error) {
@@ -427,4 +481,55 @@ func logf(w io.Writer, format string, args ...any) {
 	if w != nil {
 		fmt.Fprintf(w, format, args...)
 	}
+}
+
+// redactURL returns a display-only copy of raw with credentials masked. Both userinfo
+// (e.g. "oauth2:TOKEN@host") and query parameters (e.g. "?private_token=TOKEN") are
+// redacted, since url.Redacted alone masks only userinfo. This is for logs and error
+// messages only; the actual request URL and cache key are never altered.
+func redactURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "[redacted url]"
+	}
+
+	if parsed.User != nil {
+		parsed.User = url.User("redacted")
+	}
+
+	if parsed.RawQuery != "" {
+		values, err := url.ParseQuery(parsed.RawQuery)
+		if err != nil {
+			// Unparseable query (legacy ';' separators, bad %-encoding): fail
+			// closed rather than risk re-emitting a secret verbatim.
+			parsed.RawQuery = "redacted"
+		} else {
+			for k := range values {
+				values.Set(k, "redacted")
+			}
+
+			parsed.RawQuery = values.Encode()
+		}
+	}
+
+	return parsed.String()
+}
+
+// redactURLError returns a copy of a *url.Error with its URL redacted. A
+// *url.Error's Error() string re-embeds the full request URL — including
+// query-string credentials that the stdlib does not mask — so wrapping it with
+// %w would leak them. Rebuilding the *url.Error with a redacted URL keeps the
+// error type intact (so callers can still errors.As for *url.Error and observe
+// net.Error timeouts) while removing the credentials.
+func redactURLError(err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return &url.Error{
+			Op:  urlErr.Op,
+			URL: redactURL(urlErr.URL),
+			Err: urlErr.Err,
+		}
+	}
+
+	return err
 }

--- a/download_test.go
+++ b/download_test.go
@@ -12,12 +12,19 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 )
+
+// testRawBinaryName is a stand-in raw-binary asset filename used across download tests.
+const testRawBinaryName = "clickhouse-macos"
+
+// testArchiveFilename is a stand-in archive filename used across the SHA512 parse tests.
+const testArchiveFilename = "myfile.tgz"
 
 func TestDownloadFile(t *testing.T) {
 	t.Parallel()
@@ -62,6 +69,146 @@ func TestDownloadFile_HTTPError(t *testing.T) {
 	}
 }
 
+func TestRedactURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		raw           string
+		mustNotHave   []string // substrings that must be absent from the result
+		want          string   // exact expected result (empty = skip exact check)
+		wantUnchanged bool     // result must equal raw
+	}{
+		{
+			name:        "userinfo password",
+			raw:         "https://oauth2:glpat-SECRET@gitlab.example.com/clickhouse.tar.gz",
+			mustNotHave: []string{"glpat-SECRET"},
+		},
+		{
+			name:        "private_token query param",
+			raw:         "https://gitlab.example.com/clickhouse.tar.gz?private_token=SECRET2",
+			mustNotHave: []string{"SECRET2"},
+		},
+		{
+			name:        "both userinfo and query",
+			raw:         "https://oauth2:glpat-SECRET@gitlab.example.com/clickhouse.tar.gz?private_token=SECRET2",
+			mustNotHave: []string{"glpat-SECRET", "SECRET2"},
+		},
+		{
+			// Semicolon separators make url.ParseQuery fail; redactURL must fail
+			// closed (replace the whole query) rather than echo it verbatim.
+			name:        "unparseable query fails closed",
+			raw:         "https://gitlab.example.com/clickhouse.tar.gz?private_token=SECRET3;foo=bar",
+			mustNotHave: []string{"SECRET3"},
+		},
+		{
+			name:          "clean url unchanged",
+			raw:           "https://github.com/ClickHouse/ClickHouse/releases/download/v26.3/clickhouse.tgz",
+			wantUnchanged: true,
+		},
+		{
+			name: "unparseable",
+			raw:  "://not a url at all\x7f",
+			want: "[redacted url]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := redactURL(tt.raw)
+
+			for _, secret := range tt.mustNotHave {
+				if strings.Contains(got, secret) {
+					t.Errorf("redacted URL %q still contains secret %q", got, secret)
+				}
+			}
+
+			if tt.wantUnchanged && got != tt.raw {
+				t.Errorf("clean URL was altered: got %q, want %q", got, tt.raw)
+			}
+
+			if tt.want != "" && got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDownloadFile_HTTPError_RedactsCredentials(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	// Splice credentials into both userinfo and query of the request URL.
+	parsed, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	credURL := parsed.Scheme + "://oauth2:glpat-SECRET@" + parsed.Host + "/clickhouse.tar.gz?private_token=SECRET2"
+
+	dest := filepath.Join(t.TempDir(), "downloaded")
+
+	err = downloadFile(credURL, dest)
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+
+	if !errors.Is(err, ErrDownloadFailed) {
+		t.Fatalf("expected ErrDownloadFailed, got: %v", err)
+	}
+
+	if strings.Contains(err.Error(), "glpat-SECRET") {
+		t.Errorf("error leaked userinfo credential: %v", err)
+	}
+
+	if strings.Contains(err.Error(), "SECRET2") {
+		t.Errorf("error leaked query credential: %v", err)
+	}
+}
+
+// TestDownloadFile_TransportError_RedactsCredentials covers the transport-error
+// branch (not the HTTP-status branch): the returned *url.Error would otherwise
+// re-embed the credentialed URL through %w.
+func TestDownloadFile_TransportError_RedactsCredentials(t *testing.T) {
+	t.Parallel()
+
+	// 127.0.0.1:1 is never bound, so the dial is refused immediately.
+	credURL := "http://oauth2:glpat-SECRET@127.0.0.1:1/clickhouse.tar.gz?private_token=SECRET2"
+
+	err := downloadFile(credURL, filepath.Join(t.TempDir(), "downloaded"))
+	if err == nil {
+		t.Fatal("expected a transport error dialing a dead port")
+	}
+
+	if strings.Contains(err.Error(), "glpat-SECRET") || strings.Contains(err.Error(), "SECRET2") {
+		t.Errorf("transport error leaked credentials: %v", err)
+	}
+}
+
+// TestVerifySHA512_TransportError_RedactsCredentials covers the checksum-fetch
+// transport-error branch, which derives its URL from binaryRepositoryURL and so
+// can carry the same credentials.
+func TestVerifySHA512_TransportError_RedactsCredentials(t *testing.T) {
+	t.Parallel()
+
+	credURL := "http://oauth2:glpat-SECRET@127.0.0.1:1/clickhouse.tar.gz.sha512?private_token=SECRET2"
+
+	err := verifySHA512(filepath.Join(t.TempDir(), "file"), credURL, "clickhouse.tar.gz", false, io.Discard)
+	if err == nil {
+		t.Fatal("expected a transport error dialing a dead port")
+	}
+
+	if strings.Contains(err.Error(), "glpat-SECRET") || strings.Contains(err.Error(), "SECRET2") {
+		t.Errorf("transport error leaked credentials: %v", err)
+	}
+}
+
 func TestParseSHA512(t *testing.T) {
 	t.Parallel()
 
@@ -75,19 +222,44 @@ func TestParseSHA512(t *testing.T) {
 		{
 			name:     "standard format",
 			content:  "abc123def456  myfile.tgz\n",
-			filename: "myfile.tgz",
+			filename: testArchiveFilename,
 			want:     "abc123def456",
 		},
 		{
-			name:     "single hash line (128 chars)",
+			name:     "single bare hash line (128 hex chars)",
 			content:  "a66ab5824e9d826188a467170e7b24b031a21f936c4c5aa73e49d4c3a01dc13627523395699cea3c1d4395db391c1f8047eace1b9a28fcac4aa0eac7a5707483\n",
 			filename: "clickhouse-common-static-25.3.3.42-amd64.tgz",
+			want:     "a66ab5824e9d826188a467170e7b24b031a21f936c4c5aa73e49d4c3a01dc13627523395699cea3c1d4395db391c1f8047eace1b9a28fcac4aa0eac7a5707483",
+		},
+		{
+			name:     "GNU binary marker (*file)",
+			content:  "abc123def456 *myfile.tgz\n",
+			filename: testArchiveFilename,
+			want:     "abc123def456",
+		},
+		{
+			name:     "dot-slash prefix (./file)",
+			content:  "abc123def456  ./myfile.tgz\n",
+			filename: testArchiveFilename,
+			want:     "abc123def456",
+		},
+		{
+			name:     "single bare non-hex token",
+			content:  "not-a-valid-hash\n",
+			filename: testArchiveFilename,
+			wantErr:  true,
+		},
+		{
+			name: "ambiguous two bare hashes",
+			content: "a66ab5824e9d826188a467170e7b24b031a21f936c4c5aa73e49d4c3a01dc13627523395699cea3c1d4395db391c1f8047eace1b9a28fcac4aa0eac7a5707483\n" +
+				"b66ab5824e9d826188a467170e7b24b031a21f936c4c5aa73e49d4c3a01dc13627523395699cea3c1d4395db391c1f8047eace1b9a28fcac4aa0eac7a5707483\n",
+			filename: testArchiveFilename,
 			wantErr:  true,
 		},
 		{
 			name:     "filename not found",
 			content:  "abc123  otherfile.tgz\n",
-			filename: "myfile.tgz",
+			filename: testArchiveFilename,
 			wantErr:  true,
 		},
 	}
@@ -131,7 +303,7 @@ func TestVerifySHA512(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	err := verifySHA512(filePath, ts.URL, "testfile.tgz", nil)
+	err := verifySHA512(filePath, ts.URL, "testfile.tgz", false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +325,7 @@ func TestVerifySHA512_Mismatch(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	err := verifySHA512(filePath, ts.URL, "testfile.tgz", nil)
+	err := verifySHA512(filePath, ts.URL, "testfile.tgz", false, nil)
 	if err == nil {
 		t.Fatal("expected SHA512 mismatch error")
 	}
@@ -248,7 +420,7 @@ func TestDownloadRawBinary_WithVerification(t *testing.T) {
 	binaryContent := []byte("fake clickhouse binary")
 	h := sha512.Sum512(binaryContent)
 	expectedHash := hex.EncodeToString(h[:])
-	filename := assetMacOS
+	filename := testRawBinaryName
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, ".sha512") {
@@ -278,11 +450,16 @@ func TestDownloadRawBinary_WithVerification(t *testing.T) {
 	}
 }
 
-func TestDownloadRawBinary_SHA512Unavailable(t *testing.T) {
+// TestDownloadRawBinary_SHA512Unavailable_SkippedByDefault documents that raw
+// binaries (macOS) tolerate a missing .sha512 by default: ClickHouse publishes no
+// checksum for the macOS raw binaries, so failing closed there would break Start()
+// out of the box. Archives, which always ship a checksum, stay strict — see
+// TestDownloadAndExtract_SHA512Unavailable_StrictFails.
+func TestDownloadRawBinary_SHA512Unavailable_SkippedByDefault(t *testing.T) {
 	t.Parallel()
 
 	binaryContent := []byte("fake binary no sha512")
-	filename := assetMacOS
+	filename := testRawBinaryName
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, ".sha512") {
@@ -296,10 +473,93 @@ func TestDownloadRawBinary_SHA512Unavailable(t *testing.T) {
 	tmpDir := t.TempDir()
 	binPath := filepath.Join(tmpDir, filename)
 	asset := platformAsset{filename: filename, assetType: assetRawBinary}
-	cfg := DefaultConfig().BinaryRepositoryURL(ts.URL).CachePath(tmpDir)
+
+	// Default config (no AllowMissingChecksum): the raw-binary path still proceeds.
+	cfg := DefaultConfig().BinaryRepositoryURL(ts.URL).CachePath(tmpDir).Logger(io.Discard)
+
+	if err := downloadRawBinary(cfg, asset, ts.URL+"/"+filename, binPath); err != nil {
+		t.Fatalf("raw binary with no upstream checksum should succeed by default, got: %v", err)
+	}
+
+	got, err := os.ReadFile(binPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(got, binaryContent) {
+		t.Errorf("binary content mismatch")
+	}
+}
+
+func TestDownloadRawBinary_SHA512Unavailable_AllowMissing(t *testing.T) {
+	t.Parallel()
+
+	binaryContent := []byte("fake binary no sha512")
+	filename := testRawBinaryName
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ".sha512") {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			w.Write(binaryContent)
+		}
+	}))
+	defer ts.Close()
+
+	tmpDir := t.TempDir()
+	binPath := filepath.Join(tmpDir, filename)
+	asset := platformAsset{filename: filename, assetType: assetRawBinary}
+
+	// Opt-in: tolerate the missing checksum and write the binary.
+	cfg := DefaultConfig().
+		BinaryRepositoryURL(ts.URL).
+		CachePath(tmpDir).
+		AllowMissingChecksum(true).
+		Logger(io.Discard)
 
 	if err := downloadRawBinary(cfg, asset, ts.URL+"/"+filename, binPath); err != nil {
 		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(binPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(got, binaryContent) {
+		t.Errorf("binary content mismatch")
+	}
+}
+
+// TestDownloadAndExtract_SHA512Unavailable_StrictFails verifies the security
+// improvement for the archive (Linux) path: a missing .sha512 fails closed by
+// default — archives always ship a checksum upstream, so a 404 is suspicious —
+// and no binary is cached.
+func TestDownloadAndExtract_SHA512Unavailable_StrictFails(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ".sha512") {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			// Verification fails before extraction, so any archive body works.
+			fmt.Fprint(w, "not really a tgz")
+		}
+	}))
+	defer ts.Close()
+
+	tmpDir := t.TempDir()
+	asset := platformAsset{filename: "clickhouse-common-static-x.tgz", assetType: assetArchive}
+	binPath := filepath.Join(tmpDir, "clickhouse")
+	cfg := DefaultConfig().BinaryRepositoryURL(ts.URL).CachePath(tmpDir).Logger(io.Discard)
+
+	err := downloadAndExtract(cfg, ts.URL+"/"+asset.filename, asset, binPath)
+	if !errors.Is(err, ErrSHA512Unavailable) {
+		t.Fatalf("expected ErrSHA512Unavailable for an archive with no checksum, got: %v", err)
+	}
+
+	if _, statErr := os.Stat(binPath); !os.IsNotExist(statErr) {
+		t.Errorf("binary should not be written on strict failure; stat err = %v", statErr)
 	}
 }
 


### PR DESCRIPTION
Audit items 4 and 5 (REVIEW.md).

## Item 4 — checksum policy
Verification failed *open* on a missing `.sha512` (a 404 silently disabled integrity), while `parseSHA512` *hard-failed* on valid-but-formatted sha512sum output (bare hash, `*file`, `./file`).
- Now **fails closed by default for archive downloads** (Linux `.tgz`, which always ship a `.sha512`), returning `ErrSHA512Unavailable`.
- **Raw-binary downloads (macOS) tolerate a missing checksum** — ClickHouse publishes none for them (verified: `clickhouse-macos.sha512` -> 404), so failing closed there would break `Start()` out of the box. ⚠️ This is the one place I diverged from REVIEW.mds blanket "fail-closed by default," which would have regressed macOS.
- `AllowMissingChecksum` opts the **archive** path into skipping (air-gapped/internal mirrors).
- `parseSHA512` tolerates the common sha512sum variants without ever false-accepting.

## Item 5 — credential redaction
The full `customArchiveURL`/`binaryRepositoryURL` (which carry private-mirror credentials) leaked into logs and wrapped errors.
- `redactURL` masks userinfo **and** query params, and fails *closed* on unparseable queries.
- Both transport-error sites (`downloadFile` and `verifySHA512`) unwrap the `*url.Error` before `%w` so a network failure cannot leak query credentials; `errors.Is`/`As` chains preserved.

## Testing
- New redaction tests (userinfo, query, semicolon fail-closed, both transport-error paths), archive strict-fail + raw skip-by-default tests.
- Verified end-to-end via a cold-cache integration download (real `.sha512` fetch + fail-closed verify passes for the Linux default).
- `go test -short -race`, `go vet`, `gofmt`, `golangci-lint` (0 issues) all green.

> **Stacked on `fix/p1-cache-integrity`** — review/merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration option to allow downloads when SHA512 checksum files are unavailable for raw binary artifacts.

* **Security**
  * Enhanced credential redaction in error messages and logs to prevent sensitive information exposure.

* **Improvements**
  * Extended checksum verification to support multiple file formats for improved compatibility.
  * Stricter SHA512 verification enforcement for archive downloads by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->