### PR TITLE
chore: bump golangci-lint to v2.12.2 and fix all lint issues

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -1,7 +1,7 @@
 tools:
   - name: golangci-lint
     version:
-      want: v2.10.1
+      want: v2.12.2
     method: github-release
     with:
       repo: golangci/golangci-lint

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"sync"
 	"testing"
 )
@@ -120,8 +121,8 @@ func (e *EmbeddedClickHouse) Start() error { //nolint:cyclop // cluster guard ad
 
 	cleanups := make([]func(), 0)
 	cleanup := func() {
-		for i := len(cleanups) - 1; i >= 0; i-- {
-			cleanups[i]()
+		for _, fn := range slices.Backward(cleanups) {
+			fn()
 		}
 	}
 

--- a/cluster.go
+++ b/cluster.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -101,8 +102,8 @@ func (c *Cluster) Start() error { //nolint:funlen // multi-phase orchestrator
 
 	cleanups := make([]func(), 0)
 	cleanup := func() {
-		for i := len(cleanups) - 1; i >= 0; i-- {
-			cleanups[i]()
+		for _, fn := range slices.Backward(cleanups) {
+			fn()
 		}
 	}
 
@@ -211,9 +212,7 @@ func (c *Cluster) Stop() error {
 	var errs []error
 
 	// Stop in reverse order.
-	for i := len(c.nodes) - 1; i >= 0; i-- {
-		node := c.nodes[i]
-
+	for i, node := range slices.Backward(c.nodes) {
 		node.mu.Lock()
 
 		if err := stopProcess(node.cmd, c.config.stopTimeout); err != nil {

--- a/cluster_config_test.go
+++ b/cluster_config_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 )
 
+const testKeyMaxServerMemoryUsage = "max_server_memory_usage"
+
 func threeNodeTopology() clusterTopology {
 	ports := []clusterNodePorts{
 		{TCP: 19000, HTTP: 18123, Interserver: 19009, Keeper: 19181, KeeperRaft: 19234},
@@ -151,11 +153,11 @@ func TestBuildClusterTopology_UserSettings(t *testing.T) {
 	topo := buildClusterTopology([]clusterNodePorts{
 		{TCP: 1, HTTP: 2, Interserver: 3, Keeper: 4, KeeperRaft: 5},
 	}, map[string]string{
-		"max_server_memory_usage": "2147483648",
+		testKeyMaxServerMemoryUsage: "2147483648",
 	})
 
-	if topo.Settings["max_server_memory_usage"] != "2147483648" {
-		t.Errorf("expected user setting, got %s", topo.Settings["max_server_memory_usage"])
+	if topo.Settings[testKeyMaxServerMemoryUsage] != "2147483648" {
+		t.Errorf("expected user setting, got %s", topo.Settings[testKeyMaxServerMemoryUsage])
 	}
 }
 
@@ -165,9 +167,9 @@ func TestWriteClusterNodeConfig_SettingsSortedDeterministically(t *testing.T) {
 	topo := buildClusterTopology(
 		[]clusterNodePorts{{TCP: 1, HTTP: 2, Interserver: 3, Keeper: 4, KeeperRaft: 5}},
 		map[string]string{
-			"max_memory_usage":        "1000000000",
-			"allow_introspection":     "1",
-			"max_server_memory_usage": "2147483648",
+			"max_memory_usage":          "1000000000",
+			"allow_introspection":       "1",
+			testKeyMaxServerMemoryUsage: "2147483648",
 		},
 	)
 	dir := t.TempDir()

--- a/download_test.go
+++ b/download_test.go
@@ -247,7 +247,7 @@ func TestDownloadRawBinary_WithVerification(t *testing.T) {
 	binaryContent := []byte("fake clickhouse binary")
 	h := sha512.Sum512(binaryContent)
 	expectedHash := hex.EncodeToString(h[:])
-	filename := "clickhouse-macos"
+	filename := assetMacOS
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, ".sha512") {
@@ -281,7 +281,7 @@ func TestDownloadRawBinary_SHA512Unavailable(t *testing.T) {
 	t.Parallel()
 
 	binaryContent := []byte("fake binary no sha512")
-	filename := "clickhouse-macos"
+	filename := assetMacOS
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, ".sha512") {

--- a/platform.go
+++ b/platform.go
@@ -8,6 +8,14 @@ import (
 
 const defaultBaseURL = "https://github.com/ClickHouse/ClickHouse/releases/download"
 
+const (
+	archAMD64 = "amd64"
+	archARM64 = "arm64"
+
+	assetMacOS        = "clickhouse-macos"
+	assetMacOSAARCH64 = "clickhouse-macos-aarch64"
+)
+
 type assetType int
 
 const (
@@ -65,10 +73,10 @@ func resolveAsset(version ClickHouseVersion, goos, goarch string) (platformAsset
 
 func linuxArch(goarch string) (string, error) {
 	switch goarch {
-	case "amd64":
-		return "amd64", nil
-	case "arm64":
-		return "arm64", nil
+	case archAMD64:
+		return archAMD64, nil
+	case archARM64:
+		return archARM64, nil
 	default:
 		return "", fmt.Errorf("%w: linux/%s", ErrUnsupportedPlatform, goarch)
 	}
@@ -76,10 +84,10 @@ func linuxArch(goarch string) (string, error) {
 
 func darwinAssetName(goarch string) (string, error) {
 	switch goarch {
-	case "amd64":
-		return "clickhouse-macos", nil
-	case "arm64":
-		return "clickhouse-macos-aarch64", nil
+	case archAMD64:
+		return assetMacOS, nil
+	case archARM64:
+		return assetMacOSAARCH64, nil
 	default:
 		return "", fmt.Errorf("%w: darwin/%s", ErrUnsupportedPlatform, goarch)
 	}

--- a/platform_test.go
+++ b/platform_test.go
@@ -12,8 +12,8 @@ func TestResolveAsset_Linux(t *testing.T) {
 		arch     string
 		wantFile string
 	}{
-		{"amd64", "clickhouse-common-static-25.8.16.34-amd64.tgz"},
-		{"arm64", "clickhouse-common-static-25.8.16.34-arm64.tgz"},
+		{archAMD64, "clickhouse-common-static-25.8.16.34-amd64.tgz"},
+		{archARM64, "clickhouse-common-static-25.8.16.34-arm64.tgz"},
 	}
 	for _, tt := range tests {
 		t.Run("linux/"+tt.arch, func(t *testing.T) {
@@ -42,8 +42,8 @@ func TestResolveAsset_Darwin(t *testing.T) {
 		arch     string
 		wantFile string
 	}{
-		{"amd64", "clickhouse-macos"},
-		{"arm64", "clickhouse-macos-aarch64"},
+		{archAMD64, assetMacOS},
+		{archARM64, assetMacOSAARCH64},
 	}
 	for _, tt := range tests {
 		t.Run("darwin/"+tt.arch, func(t *testing.T) {
@@ -73,10 +73,10 @@ func TestResolveAsset_Unsupported(t *testing.T) {
 		goos string
 		arch string
 	}{
-		{"windows", "windows", "amd64"},
+		{"windows", "windows", archAMD64},
 		{"linux/386", "linux", "386"},
 		{"darwin/386", "darwin", "386"},
-		{"freebsd", "freebsd", "amd64"},
+		{"freebsd", "freebsd", archAMD64},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -131,7 +131,7 @@ func TestDownloadURL(t *testing.T) {
 func TestDownloadURL_CustomBase(t *testing.T) {
 	t.Parallel()
 
-	asset := platformAsset{filename: "clickhouse-macos-aarch64", assetType: assetRawBinary}
+	asset := platformAsset{filename: assetMacOSAARCH64, assetType: assetRawBinary}
 
 	got := downloadURL("https://mirror.example.com/releases", V25_3, asset)
 
@@ -157,7 +157,7 @@ func TestSHA512URL(t *testing.T) {
 func TestSHA512URL_Darwin(t *testing.T) {
 	t.Parallel()
 
-	asset := platformAsset{filename: "clickhouse-macos-aarch64", assetType: assetRawBinary}
+	asset := platformAsset{filename: assetMacOSAARCH64, assetType: assetRawBinary}
 
 	got := sha512URL("", V25_8, asset)
 

--- a/server_config_test.go
+++ b/server_config_test.go
@@ -72,7 +72,7 @@ func TestWriteServerConfig_OverrideMaxMemory(t *testing.T) {
 
 	dir := t.TempDir()
 	override := "2147483648" // 2 GiB
-	settings := map[string]string{"max_server_memory_usage": override}
+	settings := map[string]string{testKeyMaxServerMemoryUsage: override}
 
 	configPath, err := writeServerConfig(dir, 19000, 18123, settings)
 	if err != nil {
@@ -111,9 +111,9 @@ func TestMergeSettings(t *testing.T) {
 	t.Run("user values pass through", func(t *testing.T) {
 		t.Parallel()
 
-		got := mergeSettings(map[string]string{"max_server_memory_usage": "999"})
-		if got["max_server_memory_usage"] != "999" {
-			t.Errorf("expected value 999, got %q", got["max_server_memory_usage"])
+		got := mergeSettings(map[string]string{testKeyMaxServerMemoryUsage: "999"})
+		if got[testKeyMaxServerMemoryUsage] != "999" {
+			t.Errorf("expected value 999, got %q", got[testKeyMaxServerMemoryUsage])
 		}
 	})
 


### PR DESCRIPTION
Bumps the pinned `golangci-lint` (`.binny.yaml`) from **v2.10.1 → v2.12.2** and fixes every issue the newer version reports — **no new exclusions or `//nolint` directives** (fixes only).

## Why
v2.10.1 raised a `gosec G703` false positive on the content-addressed cache file operations (added in the cache-integrity work). Rather than downgrade the linter or suppress the rule, this bumps to the latest golangci-lint — which **no longer raises G703** there — and fixes the other issues the newer version surfaces across the (pre-existing) codebase.

## Fixes
- **modernize:** rewrite reverse loops with `slices.Backward` (`clickhouse.go`, `cluster.go`).
- **goconst:** extract arch/asset-name constants in `platform.go` and a shared test-key constant; use them across the platform/download/config tests.

## Testing
`go build`, `go vet`, `gofmt`, `go test -short -race`, and `golangci-lint run` (v2.12.2, **0 issues**) all green.

> Foundation for the P1 fix PRs (#32–#35), which are re-stacked on top of this so the whole series is clean at v2.12.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the `golangci-lint` tool version expectation from v2.10.1 to v2.12.2.

* **Refactor**
  * Streamlined reverse-order cleanup/shutdown and consolidated platform/asset identifiers using shared constants.

* **Tests**
  * Improved test maintainability by centralizing repeated platform and configuration keys/filenames via shared constants.
  * Adjusted macOS download/verification tests to use the shared macOS asset identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->