### PR TITLE
fix: monitor child process exit during startup

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"slices"
 	"sync"
 	"testing"
@@ -56,13 +55,16 @@ var ErrInvalidSettingKey = errors.New("embedded-clickhouse: invalid setting key"
 // ErrClusterManaged is returned when Start or Stop is called on a node owned by a Cluster.
 var ErrClusterManaged = errors.New("embedded-clickhouse: node is managed by a cluster; use Cluster.Start/Stop")
 
+// ErrServerExited is returned when the ClickHouse process exits during startup before becoming ready.
+var ErrServerExited = errors.New("embedded-clickhouse: server process exited during startup")
+
 // EmbeddedClickHouse manages a ClickHouse server process for testing.
 type EmbeddedClickHouse struct {
 	config Config
 
 	mu      sync.RWMutex
 	started bool
-	cmd     *exec.Cmd
+	proc    *process
 	tmpDir  string
 
 	tcpPort         uint32
@@ -186,24 +188,24 @@ func (e *EmbeddedClickHouse) Start() error { //nolint:cyclop // cluster guard ad
 		logger = os.Stdout
 	}
 
-	cmd, err := startProcess(binPath, configPath, logger)
+	proc, err := startProcess(binPath, configPath, logger)
 	if err != nil {
 		return err
 	}
 
 	cleanups = append(cleanups, func() {
-		stopProcess(cmd, e.config.stopTimeout) //nolint:errcheck
+		stopProcess(proc, e.config.stopTimeout) //nolint:errcheck
 	})
 
-	// Wait for server to be ready.
+	// Wait for server to be ready, or abort early if the process exits.
 	ctx, cancel := context.WithTimeout(context.Background(), e.config.startTimeout)
 	defer cancel()
 
-	if err := waitForReady(ctx, httpPort); err != nil {
+	if err := waitForReadyOrExit(ctx, httpPort, proc); err != nil {
 		return err
 	}
 
-	e.cmd = cmd
+	e.proc = proc
 	e.tmpDir = tmpDir
 	e.tcpPort = tcpPort
 	e.httpPort = httpPort
@@ -228,7 +230,7 @@ func (e *EmbeddedClickHouse) Stop() error {
 
 	var errs []error
 
-	if err := stopProcess(e.cmd, e.config.stopTimeout); err != nil {
+	if err := stopProcess(e.proc, e.config.stopTimeout); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -240,7 +242,7 @@ func (e *EmbeddedClickHouse) Stop() error {
 	}
 
 	e.started = false
-	e.cmd = nil
+	e.proc = nil
 	e.tcpPort = 0
 	e.httpPort = 0
 

--- a/clickhouse_test.go
+++ b/clickhouse_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"io"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -58,6 +59,64 @@ func TestSentinelErrors(t *testing.T) {
 	require.EqualError(t, ErrServerNotStarted, "embedded-clickhouse: server has not been started")
 	require.EqualError(t, ErrServerAlreadyStarted, "embedded-clickhouse: server is already started")
 	require.EqualError(t, ErrUnsupportedPlatform, "embedded-clickhouse: unsupported platform")
+}
+
+// TestStart_ChildDiesImmediately proves that when the server process exits during
+// startup, Start fails fast with ErrServerExited instead of burning the whole
+// StartTimeout, and that the cleanup path (which calls stopProcess on the already-dead
+// process) returns promptly without deadlocking on the single-shot Wait.
+func TestStart_ChildDiesImmediately(t *testing.T) {
+	t.Parallel()
+
+	fake := writeFakeBinary(t, 3)
+
+	// Hold a listener answering non-200 on /ping and pin HTTPPort to it, so the
+	// readiness probe deterministically fails (the fake binary never binds a port)
+	// and no sibling t.Parallel() test can be assigned the port and answer 200.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	httpPort := uint32(l.Addr().(*net.TCPAddr).Port)
+
+	srv := &http.Server{Handler: mux}
+
+	go srv.Serve(l)
+	defer srv.Close()
+
+	s := NewServer(
+		DefaultConfig().
+			BinaryPath(fake).
+			Logger(io.Discard).
+			HTTPPort(httpPort).
+			StartTimeout(5 * time.Second),
+	)
+
+	done := make(chan error, 1)
+
+	start := time.Now()
+
+	go func() {
+		done <- s.Start()
+	}()
+
+	select {
+	case err = <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not return; stopProcess likely deadlocked on a second Wait")
+	}
+
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, ErrServerExited)
+	assert.Less(t, elapsed, 2*time.Second, "Start should fail fast, not burn the StartTimeout")
+
+	// The server never became ready, so an explicit Stop reports not-started.
+	assert.ErrorIs(t, s.Stop(), ErrServerNotStarted)
 }
 
 // --- Integration tests (skipped in short mode) ---

--- a/cluster.go
+++ b/cluster.go
@@ -157,19 +157,19 @@ func (c *Cluster) Start() error { //nolint:funlen // multi-phase orchestrator
 			return cfgErr
 		}
 
-		cmd, startErr := startProcess(binPath, configPath, logger)
+		proc, startErr := startProcess(binPath, configPath, logger)
 		if startErr != nil {
 			return fmt.Errorf("embedded-clickhouse: start node %d: %w", i, startErr)
 		}
 
 		cleanups = append(cleanups, func() {
-			stopProcess(cmd, c.config.stopTimeout) //nolint:errcheck
+			stopProcess(proc, c.config.stopTimeout) //nolint:errcheck
 		})
 
 		nodes[i] = &EmbeddedClickHouse{
 			config:          c.config,
 			started:         true,
-			cmd:             cmd,
+			proc:            proc,
 			tmpDir:          tmpDir,
 			tcpPort:         ports[i].TCP,
 			httpPort:        ports[i].HTTP,
@@ -215,7 +215,7 @@ func (c *Cluster) Stop() error {
 	for i, node := range slices.Backward(c.nodes) {
 		node.mu.Lock()
 
-		if err := stopProcess(node.cmd, c.config.stopTimeout); err != nil {
+		if err := stopProcess(node.proc, c.config.stopTimeout); err != nil {
 			errs = append(errs, fmt.Errorf("node %d: %w", i, err))
 		}
 
@@ -226,7 +226,7 @@ func (c *Cluster) Stop() error {
 		}
 
 		node.started = false
-		node.cmd = nil
+		node.proc = nil
 		node.mu.Unlock()
 	}
 
@@ -307,21 +307,31 @@ func allocateClusterNodePorts() (clusterNodePorts, error) {
 }
 
 // waitForAllNodesReady waits for every node's /ping endpoint to respond, in parallel.
+// If any node's process exits (or otherwise fails) during startup, the first error
+// cancels the shared context so the remaining nodes stop polling immediately instead
+// of burning the full start timeout. Cancellation is triggered only after a real error
+// is recorded, so the genuine failure (e.g. ErrServerExited) is the first error enqueued
+// and is what gets returned — never a sibling's "context canceled" artifact.
 // Returns the first error reported by any node, or nil if all are ready.
 func waitForAllNodesReady(ctx context.Context, nodes []*EmbeddedClickHouse) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	readyErrs := make(chan error, len(nodes))
 
 	var wg sync.WaitGroup
 	for i, node := range nodes {
 		wg.Add(1)
 
-		go func(i int, port uint32) {
+		go func(i int, port uint32, p *process) {
 			defer wg.Done()
 
-			if err := waitForReady(ctx, port); err != nil {
+			if err := waitForReadyOrExit(ctx, port, p); err != nil {
 				readyErrs <- fmt.Errorf("embedded-clickhouse: node %d not ready: %w", i, err)
+
+				cancel() // stop sibling waits as soon as one node fails
 			}
-		}(i, node.httpPort)
+		}(i, node.httpPort, node.proc)
 	}
 
 	wg.Wait()

--- a/health.go
+++ b/health.go
@@ -38,6 +38,82 @@ func waitForReady(ctx context.Context, httpPort uint32) error {
 	}
 }
 
+// exitError builds the startup error for an exited server process. Call only
+// once proc.done is closed (so proc.waitErr is safe to read).
+func exitError(proc *process) error {
+	if proc.waitErr != nil {
+		return fmt.Errorf("%w: %w", ErrServerExited, proc.waitErr)
+	}
+
+	return ErrServerExited
+}
+
+// waitForReadyOrExit polls the ClickHouse HTTP /ping endpoint until it returns HTTP 200,
+// the context is cancelled, or the server process exits. If the process exits before
+// becoming ready, it returns ErrServerExited (wrapping the underlying wait error, if any)
+// immediately instead of burning the entire start timeout. Process exit always wins over
+// a readiness response, so a child that has already died is never reported ready (even if
+// another process answers /ping on a user-fixed port).
+func waitForReadyOrExit(ctx context.Context, httpPort uint32, proc *process) error {
+	url := fmt.Sprintf("http://127.0.0.1:%d/ping", httpPort)
+	client := &http.Client{Timeout: healthRequestTimeout}
+
+	// exited reports the process-exit error if the child has already exited, else nil.
+	exited := func() error {
+		select {
+		case <-proc.done:
+			return exitError(proc)
+		default:
+			return nil
+		}
+	}
+
+	// check reports (ready, error): error if the process exited (checked both before and
+	// after the ping, so a child that dies around the probe is never reported ready);
+	// ready is true only on a /ping 200.
+	check := func() (bool, error) {
+		if err := exited(); err != nil {
+			return false, err
+		}
+
+		if !ping(ctx, client, url) {
+			return false, nil
+		}
+
+		if err := exited(); err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	// Immediate poll to avoid unnecessary 100ms latency when the server is already up.
+	if ready, err := check(); err != nil || ready {
+		return err
+	}
+
+	ticker := time.NewTicker(healthPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Prefer the specific exit error if the process died around the deadline.
+			if err := exited(); err != nil {
+				return err
+			}
+
+			return fmt.Errorf("embedded-clickhouse: server did not become ready: %w", ctx.Err())
+		case <-proc.done:
+			return exitError(proc)
+		case <-ticker.C:
+			if ready, err := check(); err != nil || ready {
+				return err
+			}
+		}
+	}
+}
+
 func ping(ctx context.Context, client *http.Client, url string) bool {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/health_test.go
+++ b/health_test.go
@@ -2,12 +2,17 @@ package embeddedclickhouse
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"testing"
 	"time"
 )
+
+// errTestProcExit is a static stand-in for a process wait error in tests
+// (a static sentinel rather than an inline errors.New, per err113).
+var errTestProcExit = errors.New("embedded-clickhouse: test process exited")
 
 func TestWaitForReady_ImmediateSuccess(t *testing.T) {
 	t.Parallel()
@@ -104,6 +109,85 @@ func TestWaitForReady_DelayedStart(t *testing.T) {
 	err = waitForReady(ctx, port)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestWaitForReadyOrExit_ReadyWins(t *testing.T) {
+	t.Parallel()
+
+	// Serve /ping with 200. p.done is never closed, so readiness must win.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "Ok.\n")
+	})
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	port := uint32(l.Addr().(*net.TCPAddr).Port)
+
+	srv := &http.Server{Handler: mux}
+
+	go srv.Serve(l)
+	defer srv.Close()
+
+	// A process whose done channel is never closed: it must not influence the result.
+	proc := &process{cmd: nil, done: make(chan struct{}), waitErr: nil}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := waitForReadyOrExit(ctx, port, proc); err != nil {
+		t.Fatalf("waitForReadyOrExit = %v, want nil", err)
+	}
+}
+
+func TestWaitForReadyOrExit_EarlyExit(t *testing.T) {
+	t.Parallel()
+
+	// Hold a listener that answers non-200 on /ping for the whole test: the
+	// readiness probe then deterministically fails and the port stays bound, so a
+	// sibling t.Parallel() test cannot be reassigned it and answer 200 (the
+	// ephemeral-port-reuse flake that allocatePort() would expose).
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	port := uint32(l.Addr().(*net.TCPAddr).Port)
+
+	srv := &http.Server{Handler: mux}
+
+	go srv.Serve(l)
+	defer srv.Close()
+
+	// A process that has already exited with a non-nil error.
+	done := make(chan struct{})
+	close(done)
+
+	proc := &process{cmd: nil, done: done, waitErr: errTestProcExit}
+
+	// Generous context: the early-exit path, not the deadline, must end the wait.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err = waitForReadyOrExit(ctx, port, proc)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrServerExited) {
+		t.Fatalf("waitForReadyOrExit = %v, want ErrServerExited", err)
+	}
+
+	if elapsed > 2*time.Second {
+		t.Errorf("waitForReadyOrExit took %v, want fast early-exit", elapsed)
 	}
 }
 

--- a/process.go
+++ b/process.go
@@ -35,8 +35,20 @@ func allocatePort() (uint32, error) {
 	return port, nil
 }
 
-// startProcess launches the ClickHouse server process.
-func startProcess(binaryPath, configPath string, logger io.Writer) (*exec.Cmd, error) {
+// process wraps a started ClickHouse server command together with a single-shot
+// wait goroutine. cmd.Wait() is called exactly once (in startProcess); the result
+// is published via waitErr and broadcast by closing done. Both the startup monitor
+// (waitForReadyOrExit) and stopProcess observe completion by reading from done,
+// avoiding the "Wait was already called" error and the single-delivery-channel
+// deadlock that a second Wait or a buffered-channel handoff would cause.
+type process struct {
+	cmd     *exec.Cmd
+	done    chan struct{} // closed exactly once, after waitErr is set
+	waitErr error         // safe to read only after <-done (happens-before via close)
+}
+
+// startProcess launches the ClickHouse server process and starts the single Wait goroutine.
+func startProcess(binaryPath, configPath string, logger io.Writer) (*process, error) {
 	//nolint:noctx // lifecycle managed via SIGTERM/SIGKILL, not context
 	cmd := exec.Command(binaryPath, "server", "--config-file="+configPath)
 	cmd.Stdout = logger
@@ -48,52 +60,83 @@ func startProcess(binaryPath, configPath string, logger io.Writer) (*exec.Cmd, e
 		return nil, fmt.Errorf("embedded-clickhouse: start process: %w", err)
 	}
 
-	return cmd, nil
+	proc := &process{cmd: cmd, done: make(chan struct{}), waitErr: nil}
+
+	go func() {
+		proc.waitErr = cmd.Wait()
+		close(proc.done)
+	}()
+
+	return proc, nil
 }
 
 // stopProcess sends SIGTERM and waits for graceful shutdown, then SIGKILL if needed.
-func stopProcess(cmd *exec.Cmd, timeout time.Duration) error {
-	if cmd == nil || cmd.Process == nil {
+// It never calls cmd.Wait() — that is owned by the goroutine started in startProcess.
+// Instead it observes completion via proc.done and classifies proc.waitErr.
+func stopProcess(proc *process, timeout time.Duration) error {
+	if proc == nil || proc.cmd == nil || proc.cmd.Process == nil {
 		return nil
 	}
 
+	// If the process has already exited (e.g. it died during startup and the
+	// cleanup path is now stopping it), skip signaling: the PID has been reaped
+	// and could be recycled to an unrelated process group.
+	select {
+	case <-proc.done:
+		return classifyWaitErr(proc.waitErr)
+	default:
+	}
+
 	// Send SIGTERM to the process group.
-	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	pgid, err := syscall.Getpgid(proc.cmd.Process.Pid)
 	if err != nil {
-		return nil //nolint:nilerr // Getpgid fails when process is already gone — not an error.
+		// The process is already gone — it may have exited in the race between the
+		// non-blocking check above and now. Drain the Wait result and classify it
+		// rather than masking a recorded abnormal exit with a nil return.
+		<-proc.done
+
+		return classifyWaitErr(proc.waitErr)
 	}
 
 	_ = syscall.Kill(-pgid, syscall.SIGTERM)
 
-	done := make(chan error, 1)
-
-	go func() {
-		done <- cmd.Wait()
-	}()
-
 	select {
 	case <-time.After(timeout):
-		// Force kill after timeout.
-		_ = syscall.Kill(-pgid, syscall.SIGKILL)
-
-		<-done
-
-		return ErrStopTimeout
-	case err := <-done:
-		if err != nil {
-			// Exit status from SIGTERM is expected, not an error.
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) {
-				if exitErr.ExitCode() == -1 || exitErr.ExitCode() == 143 {
-					return nil
-				}
-
-				return err
-			}
-			// Non-ExitError (e.g., I/O error waiting on process): surface it.
-			return err
+		// If the process exited right at the deadline, prefer the real exit
+		// classification over a timeout.
+		select {
+		case <-proc.done:
+			return classifyWaitErr(proc.waitErr)
+		default:
 		}
 
+		// Force kill after timeout, then wait for the Wait goroutine to finish.
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+
+		<-proc.done
+
+		return ErrStopTimeout
+	case <-proc.done:
+		return classifyWaitErr(proc.waitErr)
+	}
+}
+
+// classifyWaitErr maps cmd.Wait()'s error to a stop result. An exit caused by our
+// SIGTERM/SIGKILL (exit code -1 for signals, or 143 = 128+SIGTERM) is expected and
+// reported as success; any other exit or I/O error is surfaced.
+func classifyWaitErr(err error) error {
+	if err == nil {
 		return nil
 	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if exitErr.ExitCode() == -1 || exitErr.ExitCode() == 143 {
+			return nil
+		}
+
+		return err
+	}
+	// Non-ExitError (e.g., I/O error waiting on process): surface it.
+	return err
 }

--- a/process_test.go
+++ b/process_test.go
@@ -1,8 +1,67 @@
 package embeddedclickhouse
 
 import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 )
+
+// writeFakeBinary writes an executable shell script to t.TempDir() that ignores its
+// arguments and exits with the given code. It skips the test on platforms without
+// /bin/sh (e.g. Windows). Returns the absolute path to the script.
+func writeFakeBinary(t *testing.T, exitCode int) string {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("fake /bin/sh binary not supported on windows")
+	}
+
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("/bin/sh not available")
+	}
+
+	path := filepath.Join(t.TempDir(), "fake-clickhouse.sh")
+
+	script := "#!/bin/sh\nexit " + itoa(exitCode) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	return path
+}
+
+// itoa avoids pulling strconv into the test for a single small integer.
+func itoa(num int) string {
+	if num == 0 {
+		return "0"
+	}
+
+	neg := num < 0
+	if neg {
+		num = -num
+	}
+
+	var buf [20]byte
+
+	i := len(buf)
+	for num > 0 {
+		i--
+		buf[i] = byte('0' + num%10)
+		num /= 10
+	}
+
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+
+	return string(buf[i:])
+}
 
 func TestAllocatePort(t *testing.T) {
 	t.Parallel()
@@ -44,8 +103,48 @@ func TestAllocatePort_Unique(t *testing.T) {
 func TestStopProcess_NilCmd(t *testing.T) {
 	t.Parallel()
 
-	err := stopProcess(nil, 0)
-	if err != nil {
+	// nil *process and a zero-value *process (no cmd) must both be no-ops.
+	if err := stopProcess(nil, 0); err != nil {
 		t.Errorf("stopProcess(nil) = %v, want nil", err)
+	}
+
+	if err := stopProcess(&process{cmd: nil, done: nil, waitErr: nil}, 0); err != nil {
+		t.Errorf("stopProcess(&process{}) = %v, want nil", err)
+	}
+}
+
+func TestStartProcess_ExitErrorCaptured(t *testing.T) {
+	t.Parallel()
+
+	fake := writeFakeBinary(t, 3)
+
+	proc, err := startProcess(fake, "ignored-config", io.Discard)
+	if err != nil {
+		t.Fatalf("startProcess: %v", err)
+	}
+
+	// The single Wait goroutine must publish the exit status via waitErr after done closes.
+	<-proc.done
+
+	var exitErr *exec.ExitError
+	if !errors.As(proc.waitErr, &exitErr) {
+		t.Fatalf("proc.waitErr = %v, want *exec.ExitError", proc.waitErr)
+	}
+
+	if exitErr.ExitCode() != 3 {
+		t.Errorf("exit code = %d, want 3", exitErr.ExitCode())
+	}
+
+	// stopProcess on an already-exited (and reaped) process must not call Wait again
+	// and must return promptly. Once the process is gone, Getpgid fails and stop is a
+	// no-op (nil); the important guarantee is that it does not hang on a second Wait.
+	stopDone := make(chan error, 1)
+
+	go func() { stopDone <- stopProcess(proc, time.Second) }()
+
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stopProcess hung; likely a second cmd.Wait or single-delivery deadlock")
 	}
 }


### PR DESCRIPTION
**Supersedes #32** (auto-closed when its base `chore/golangci-v2.12.2` branch was deleted on merge of #36). Rebased onto `main` (which now includes the v2.12.2 lint bump). All of #32's review feedback is addressed in this branch — see the resolved threads on #32.

Audit item 1: `Start` and `Cluster.Start` now watch the child during startup. A single Wait goroutine owns `cmd.Wait()` and broadcasts the result by closing a `done` channel; `waitForReadyOrExit` selects over readiness, the start timeout, and process exit, returning `ErrServerExited` immediately instead of burning the whole `StartTimeout`. `stopProcess` reads the same channel (never a second Wait).

Review fixes folded in:
- **Process exit takes precedence over a `/ping` 200** (CodeRabbit) — a dead child is never reported ready even if another process answers on a user-fixed port.
- **`stopProcess` Getpgid race** (CodeRabbit) — the Getpgid-error branch drains `done` and classifies the exit instead of masking it with `nil`.
- Tests use a held non-200 listener (no `allocatePort` reuse race) and a static sentinel error (Gemini; `errors.New` literal would itself fail `err113`).

## Testing
`go build`/`vet`/`gofmt`, `go test -short -race`, golangci-lint **v2.12.2 = 0 issues**, plus real-ClickHouse integration (`TestIntegration_StartStop`/`ParallelInstances`) under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `ErrServerExited` error to indicate the embedded ClickHouse server process terminated before initialization completed.

* **Bug Fixes**
  * Improved startup reliability by failing fast when the server process exits during readiness checks, avoiding unnecessary waits.
  * Updated readiness behavior so process exit takes precedence over `/ping` responses, and shutdown uses the correct running instance state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->