### PR TITLE
Export EnsureBinary for programmatic binary resolution

### DIFF
--- a/download.go
+++ b/download.go
@@ -18,6 +18,19 @@ import (
 // httpClient is a shared HTTP client with a timeout to prevent indefinite hangs on slow CDNs.
 var httpClient = &http.Client{Timeout: 10 * time.Minute} //nolint:gochecknoglobals
 
+// EnsureBinary resolves the ClickHouse binary described by cfg, downloading,
+// verifying, and caching it if necessary, and returns the path to the
+// executable. It performs no server startup — callers that only need the binary
+// (for example, to run `clickhouse local`) can use the returned path directly.
+//
+// Resolution follows the same precedence as Start: an explicit Config.BinaryPath
+// is honored as-is, otherwise a custom archive (path or URL) or the standard
+// GitHub release download is used, with SHA verification and on-disk caching
+// (content-addressed for custom assets, version-pinned for standard releases).
+func EnsureBinary(cfg Config) (string, error) {
+	return ensureBinary(cfg)
+}
+
 // ensureBinary returns the path to a ClickHouse binary, downloading it if necessary.
 func ensureBinary(cfg Config) (string, error) {
 	// Priority: BinaryPath > CustomArchivePath > CustomArchiveURL > standard download.

--- a/download_test.go
+++ b/download_test.go
@@ -354,6 +354,31 @@ func TestEnsureBinary_ExplicitPath(t *testing.T) {
 	}
 }
 
+// TestEnsureBinary_Exported verifies the exported EnsureBinary wrapper resolves an
+// explicit BinaryPath without any network access, mirroring TestEnsureBinary_ExplicitPath.
+func TestEnsureBinary_Exported(t *testing.T) {
+	t.Parallel()
+
+	// Create a fake binary.
+	tmpDir := t.TempDir()
+
+	binPath := filepath.Join(tmpDir, "clickhouse")
+	if err := os.WriteFile(binPath, []byte("fake"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := DefaultConfig().BinaryPath(binPath)
+
+	got, err := EnsureBinary(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got != binPath {
+		t.Errorf("binary = %q, want %q", got, binPath)
+	}
+}
+
 func TestEnsureBinary_ExplicitPathNotFound(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Some consumers need the resolved `clickhouse` binary path — to run `clickhouse local` — without starting a server. Until now the only public handle on binary resolution was the `Config.BinaryPath(...)` setter, with no exported way to *trigger* resolution (download → SHA-verify → cache → extract) and read back the resulting path.

This adds a thin exported wrapper `EnsureBinary(cfg Config) (string, error)` over the existing internal `ensureBinary`. It performs no server startup and honors the same precedence as `Start` (explicit `Config.BinaryPath` > custom archive path/URL > standard GitHub-release download).

- No behavior change: `EnsureBinary` simply calls `ensureBinary`.
- Unit-tested via the explicit-`BinaryPath` path (`TestEnsureBinary_Exported`), mirroring `TestEnsureBinary_ExplicitPath` — no network access.
- No version bumps, dependency changes, or unrelated edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public API to resolve, verify, and cache the ClickHouse binary without starting a server.
  * Supports using an explicitly configured local binary path without requiring network access.

* **Tests**
  * Added coverage confirming the public binary-resolution API returns the configured executable path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->